### PR TITLE
fix: support nvim stable by using goto_next instead of jump

### DIFF
--- a/lua/demicolon/jump.lua
+++ b/lua/demicolon/jump.lua
@@ -50,7 +50,15 @@ function M.diagnostic_jump(opts)
         vim.diagnostic.jump(o)
       else
         -- Deprecated in favor of `vim.diagnostic.jump` in Neovim 0.11.0
-        vim.diagnostic.goto_next(o)
+        if o.count > 0 then
+          vim.diagnostic.goto_next({
+            float = o.float,
+          })
+        else
+          vim.diagnostic.goto_prev({
+            float = o.float,
+          })
+        end
       end
     end, opts)
   end

--- a/lua/demicolon/jump.lua
+++ b/lua/demicolon/jump.lua
@@ -46,7 +46,12 @@ function M.diagnostic_jump(opts)
       local count = o.forward and 1 or -1
       o.count = count * vim.v.count1
 
-      vim.diagnostic.jump(o)
+      if vim.diagnostic.jump then
+        vim.diagnostic.jump(o)
+      else
+        -- Deprecated in favor of `vim.diagnostic.jump` in Neovim 0.11.0
+        vim.diagnostic.goto_next(o)
+      end
     end, opts)
   end
 end


### PR DESCRIPTION
I'm on neovim version v.0.10.1 and `vim.diagnostic.jump` is not available. Because it got [just introduced](https://neovim.io/doc/user/deprecated.html#vim.diagnostic.goto_next()) in 0.11.0, which is not released yet . You have to use `vim.diagnostic.goto_next` and `vim.diagnostics.goto_prev`, which I've implemented now.

And thanks for the plugin! I had some similar mechanism in my own config, which I could now remove.