### PR TITLE
feat: add desc to key maps

### DIFF
--- a/lua/demicolon/integrations/gitsigns.lua
+++ b/lua/demicolon/integrations/gitsigns.lua
@@ -24,9 +24,9 @@ function M.create_keymaps()
   local nxo = { 'n', 'x', 'o' }
 
   ---@diagnostic disable-next-line: need-check-nil
-  vim.keymap.set(nxo, options.keymaps.next, M.jump({ forward = true }))
+  vim.keymap.set(nxo, options.keymaps.next, M.jump({ forward = true }), {desc = "Next hunk"})
   ---@diagnostic disable-next-line: need-check-nil
-  vim.keymap.set(nxo, options.keymaps.prev, M.jump({ forward = false }))
+  vim.keymap.set(nxo, options.keymaps.prev, M.jump({ forward = false }), {desc= "Previous hunk"})
 end
 
 return M

--- a/lua/demicolon/keymaps.lua
+++ b/lua/demicolon/keymaps.lua
@@ -19,16 +19,16 @@ function M.create_default_horizontal_keymaps()
 end
 
 function M.create_default_diagnostic_keymaps()
-  vim.keymap.set(nxo, ']d', jump.diagnostic_jump({ forward = true }))
-  vim.keymap.set(nxo, '[d', jump.diagnostic_jump({ forward = false }))
-  vim.keymap.set(nxo, ']e', jump.diagnostic_jump({ forward = true, severity = 'ERROR' }))
-  vim.keymap.set(nxo, '[e', jump.diagnostic_jump({ forward = false, severity = 'ERROR' }))
-  vim.keymap.set(nxo, ']w', jump.diagnostic_jump({ forward = true, severity = 'WARN' }))
-  vim.keymap.set(nxo, '[w', jump.diagnostic_jump({ forward = false, severity = 'WARN' }))
-  vim.keymap.set(nxo, ']i', jump.diagnostic_jump({ forward = true, severity = 'INFO' }))
-  vim.keymap.set(nxo, '[i', jump.diagnostic_jump({ forward = false, severity = 'INFO' }))
-  vim.keymap.set(nxo, ']h', jump.diagnostic_jump({ forward = true, severity = 'HINT' }))
-  vim.keymap.set(nxo, '[h', jump.diagnostic_jump({ forward = false, severity = 'HINT' }))
+  vim.keymap.set(nxo, ']d', jump.diagnostic_jump({ forward = true }), {desc = "Next diagnostic"})
+  vim.keymap.set(nxo, '[d', jump.diagnostic_jump({ forward = false }), {desc = "Previous diagnostic"})
+  vim.keymap.set(nxo, ']e', jump.diagnostic_jump({ forward = true, severity = 'ERROR' }), {desc = "Next error"})
+  vim.keymap.set(nxo, '[e', jump.diagnostic_jump({ forward = false, severity = 'ERROR' }), {desc = "Previous error"})
+  vim.keymap.set(nxo, ']w', jump.diagnostic_jump({ forward = true, severity = 'WARN' }), {desc = "Next warning"})
+  vim.keymap.set(nxo, '[w', jump.diagnostic_jump({ forward = false, severity = 'WARN' }), {desc = "Previous warning"})
+  vim.keymap.set(nxo, ']i', jump.diagnostic_jump({ forward = true, severity = 'INFO' }), {desc = "Next info"})
+  vim.keymap.set(nxo, '[i', jump.diagnostic_jump({ forward = false, severity = 'INFO' }), {desc = "Previous info"})
+  vim.keymap.set(nxo, ']h', jump.diagnostic_jump({ forward = true, severity = 'HINT' }), {desc = "Next hint"})
+  vim.keymap.set(nxo, '[h', jump.diagnostic_jump({ forward = false, severity = 'HINT' }), {desc = "Previous hint"})
 end
 
 return M


### PR DESCRIPTION
When using the [which-key](https://github.com/folke/which-key.nvim) plugin, it's nice to have a description for most key maps. So I've added the `desc` field to the key maps.