### PR TITLE
fix: jump with severity on neovim < v0.11.

### DIFF
--- a/lua/demicolon/jump.lua
+++ b/lua/demicolon/jump.lua
@@ -51,13 +51,9 @@ function M.diagnostic_jump(opts)
       else
         -- Deprecated in favor of `vim.diagnostic.jump` in Neovim 0.11.0
         if o.count > 0 then
-          vim.diagnostic.goto_next({
-            float = o.float,
-          })
+          vim.diagnostic.goto_next(o)
         else
-          vim.diagnostic.goto_prev({
-            float = o.float,
-          })
+          vim.diagnostic.goto_prev(o)
         end
       end
     end, opts)


### PR DESCRIPTION
Hey it's me again 😅
I've noticed when trying to jump to the next error, it just jumps to the next diagnostic. I've missed that the opts table may contain the severity field, so I now just pass the whole object to the goto_next method. It contains the `count` field as well, which isn't used by that method so it won't matter.