### PR TITLE
feat: accept boolean for float

### DIFF
--- a/lua/demicolon/init.lua
+++ b/lua/demicolon/init.lua
@@ -3,7 +3,7 @@ local keymaps = require('demicolon.keymaps')
 local M = {}
 
 ---@class DemicolonDiagnosticOptions
----@field float? vim.diagnostic.Opts.Float Default options passed to diagnostic floating window
+---@field float? boolean|vim.diagnostic.Opts.Float Default options passed to diagnostic floating window
 
 ---@class DemicolonKeymapsOptions
 ---@field horizontal_motions? boolean Create `t`/`T`/`f`/`F` key mappings

--- a/lua/demicolon/jump.lua
+++ b/lua/demicolon/jump.lua
@@ -48,8 +48,8 @@ function M.diagnostic_jump(opts)
   return function()
     M.repeatably_do(function(o)
       o = o or {}
-      local options = require('demicolon').get_options()
-      o.float = vim.tbl_extend('force', o, options.diagnostic.float)
+      local float_opts = require('demicolon').get_options().diagnostic.float
+      o.float = type(float_opts) == 'table' and vim.tbl_extend('force', o, float_opts) or float_opts
 
       local count = o.forward and 1 or -1
       o.count = count * vim.v.count1


### PR DESCRIPTION
I want to repeat `[d`/`]d` mappings by `;`/`,` without diagnostic floating windows. `vim.diagnostic.config` can accept boolean for floats, so this patch enables to accept ones to do it.