### PR TITLE
feat: add vimtex integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ demicolon.nvim lets you repeat any [nvim-treesitter-textobjects](https://github.
 
 ### [VimTeX](https://github.com/lervag/vimtex) motions
 
-Note that these are only mapped in `n` and `x` modes.
+Note that these mappings are only created in normal mode and visual mode. For some reason they don't work when created for operator-pending mode.
 
 | Motion    | Jumps to next/pevious... | Help page with more information |
 | --------- | ------------------------ | ------------------------------- |

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ demicolon.nvim lets you repeat any [nvim-treesitter-textobjects](https://github.
 
 ### [VimTeX](https://github.com/lervag/vimtex) motions
 
+Note that these are only mapped in `n` and `x` modes.
+
 | Motion    | Jumps to next/pevious... | Help page with more information |
 | --------- | ------------------------ | ------------------------------- |
 | `][`/`[[` | Section start            | `:help vimtex-motions`          |

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ With [lazy.nvim](https://github.com/folke/lazy.nvim):
 {
   'mawkler/demicolon.nvim',
   -- keys = { ';', ',', 't', 'f', 'T', 'F', ']', '[', ']d', '[d' }, -- Uncomment this to lazy load
+  -- ft = 'tex',                                                    -- ...and this if you use LaTeX
   dependencies = {
     'nvim-treesitter/nvim-treesitter',
     'nvim-treesitter/nvim-treesitter-textobjects',

--- a/README.md
+++ b/README.md
@@ -80,6 +80,21 @@ demicolon.nvim lets you repeat any [nvim-treesitter-textobjects](https://github.
 | `]t`/`[t` | Test                     | `:help neotest.jump`            |
 | `]T`/`[T` | Failed test              | `:help neotest.jump`            |
 
+### [VimTeX](https://github.com/lervag/vimtex) motions
+
+| Motion    | Jumps to next/pevious... | Help page with more information |
+| --------- | ------------------------ | ------------------------------- |
+| `][`/`[[` | Section start            | `:help vimtex-motions`          |
+| `]]`/`[]` | Section end              | `:help vimtex-motions`          |
+| `]r`/`[r` | Frame start              | `:help vimtex-motions`          |
+| `]R`/`[R` | Frame end                | `:help vimtex-motions`          |
+| `]n`/`[n` | Math start               | `:help vimtex-motions`          |
+| `]N`/`[N` | Math end                 | `:help vimtex-motions`          |
+| `]/`/`[/` | Comment start            | `:help vimtex-motions`          |
+| `]*`/`[*` | Comment end              | `:help vimtex-motions`          |
+| `]m`/`[m` | Environment start        | `:help vimtex-motions`          |
+| `]M`/`[M` | Environment end          | `:help vimtex-motions`          |
+
 ## Configuration
 
 Default options:
@@ -127,6 +142,52 @@ opts = {
           prev = '[T',
         },
       },
+    },
+    -- Integration with https://github.com/lervag/vimtex
+    vimtex = {
+      enabled = true,
+      keymaps = {
+        section_start = {
+          next = '][',
+          prev = '[[',
+        },
+        section_end = {
+          next = ']]',
+          prev = '[]',
+        },
+        frame_start = {
+          next = ']r',
+          prev = '[r',
+        },
+        frame_end = {
+          next = ']R',
+          prev = '[R',
+        },
+        math_start = {
+          next = ']n',
+          prev = '[n',
+        },
+        math_end = {
+          next = ']N',
+          prev = '[N',
+        },
+        comment_start = {
+          next = ']/',
+          prev = '[/',
+        },
+        comment_end = {
+          next = ']*',
+          prev = '[*',
+        },
+        environment_start = {
+          next = ']m',
+          prev = '[m',
+        },
+        environment_end = {
+          next = ']M',
+          prev = '[M',
+        },
+      }
     },
   },
 }

--- a/doc/demicolon.txt
+++ b/doc/demicolon.txt
@@ -1,4 +1,4 @@
-*demicolon.txt*          For NVIM v0.8.0          Last change: 2025 January 24
+*demicolon.txt*          For NVIM v0.8.0          Last change: 2025 January 29
 
 ==============================================================================
 Table of Contents                                *demicolon-table-of-contents*

--- a/lua/demicolon/init.lua
+++ b/lua/demicolon/init.lua
@@ -30,7 +30,7 @@ local M = {}
 ---@field keymaps? DemicolonNeotestKeymapOptions
 
 ---@class DemicolonVimtexKeymapOptions
----@field section_begin? DemicolonIntegrationKeymaps
+---@field section_start? DemicolonIntegrationKeymaps
 ---@field section_end? DemicolonIntegrationKeymaps
 ---@field frame_start? DemicolonIntegrationKeymaps
 ---@field frame_end? DemicolonIntegrationKeymaps
@@ -90,7 +90,7 @@ local options = {
     vimtex = {
       enabled = true,
       keymaps = {
-        section_begin = {
+        section_start = {
           next = '][',
           prev = '[[',
         },

--- a/lua/demicolon/init.lua
+++ b/lua/demicolon/init.lua
@@ -119,8 +119,8 @@ local options = {
           prev = '[/',
         },
         comment_end = {
-          next = ']%',
-          prev = '[%',
+          next = ']*',
+          prev = '[*',
         },
         environment_start = {
           next = ']m',

--- a/lua/demicolon/init.lua
+++ b/lua/demicolon/init.lua
@@ -29,9 +29,26 @@ local M = {}
 ---@field enabled? boolean
 ---@field keymaps? DemicolonNeotestKeymapOptions
 
+---@class DemicolonVimtexKeymapOptions
+---@field section_begin? DemicolonIntegrationKeymaps
+---@field section_end? DemicolonIntegrationKeymaps
+---@field frame_start? DemicolonIntegrationKeymaps
+---@field frame_end? DemicolonIntegrationKeymaps
+---@field math_start? DemicolonIntegrationKeymaps
+---@field math_end? DemicolonIntegrationKeymaps
+---@field comment_start? DemicolonIntegrationKeymaps
+---@field comment_end? DemicolonIntegrationKeymaps
+---@field environment_start? DemicolonIntegrationKeymaps
+---@field environment_end? DemicolonIntegrationKeymaps
+
+---@class DemicolonVimtexOptions
+---@field enabled? boolean
+---@field keymaps? DemicolonVimtexKeymapOptions
+
 ---@class DemicolonIntegrationOptions
 ---@field gitsigns? DemicolonGitsignsOptions Integration with https://github.com/lewis6991/gitsigns.nvim
 ---@field neotest? DemicolonNeotestOptions Integration with https://github.com/nvim-neotest/neotest
+---@field vimtex? DemicolonVimtexOptions Integration with https://github.com/lervag/vimtex
 
 ---@class DemicolonOptions
 ---@field diagnostic? DemicolonDiagnosticOptions Diagnostic options
@@ -70,6 +87,51 @@ local options = {
         },
       },
     },
+    vimtex = {
+      enabled = true,
+      keymaps = {
+        section_begin = {
+          next = '][',
+          prev = '[[',
+        },
+        section_end = {
+          next = ']]',
+          prev = '[]',
+        },
+        frame_start = {
+          next = ']r',
+          prev = '[r',
+        },
+        frame_end = {
+          next = ']R',
+          prev = '[R',
+        },
+        math_start = {
+          next = ']n',
+          prev = '[n',
+        },
+        math_end = {
+          next = ']N',
+          prev = '[N',
+        },
+        comment_start = {
+          next = ']/',
+          prev = '[/',
+        },
+        comment_end = {
+          next = ']%',
+          prev = '[%',
+        },
+        environment_start = {
+          next = ']m',
+          prev = '[m',
+        },
+        environment_end = {
+          next = ']M',
+          prev = '[M',
+        },
+      }
+    }
   },
 }
 
@@ -112,6 +174,10 @@ function M.setup(opts)
 
   if options.integrations.neotest.enabled then
     require('demicolon.integrations.neotest').create_keymaps()
+  end
+
+  if options.integrations.vimtex.enabled then
+    require('demicolon.integrations.vimtex').create_keymaps()
   end
 end
 

--- a/lua/demicolon/integrations/gitsigns.lua
+++ b/lua/demicolon/integrations/gitsigns.lua
@@ -10,7 +10,7 @@ function M.jump(options)
       else
         local exists, gitsigns = pcall(require, 'gitsigns')
         if not exists then
-          vim.notify('diagnostic.nvim: gitsigns.nvim is not installed', vim.log.levels.WARN)
+          vim.notify('demicolon.nvim: gitsigns.nvim is not installed', vim.log.levels.WARN)
           return
         end
 

--- a/lua/demicolon/integrations/neotest.lua
+++ b/lua/demicolon/integrations/neotest.lua
@@ -6,7 +6,7 @@ function M.jump(options)
     require('demicolon.jump').repeatably_do(function(opts)
       local exists, neotest = pcall(require, 'neotest')
       if not exists then
-        vim.notify('diagnostic.nvim: neotest is not installed', vim.log.levels.WARN)
+        vim.notify('demicolon.nvim: neotest is not installed', vim.log.levels.WARN)
         return
       end
 

--- a/lua/demicolon/integrations/vimtex.lua
+++ b/lua/demicolon/integrations/vimtex.lua
@@ -29,7 +29,7 @@ function M.vimtex_map(key, vimtex_mapping, desc)
   -- Override only if it's a vimtex mapping or not set.
   -- That's roughly the behavior of vimtex as well:
   -- https://github.com/lervag/vimtex/blob/83e331dcad5ce28012e656eea3906b5b897db2ba/autoload/vimtex.vim#L415
-  local existing_lhs = vim.fn.maparg(vimtex_mapping, 'nxo')
+  local existing_lhs = vim.fn.maparg(vimtex_mapping, 'n')
   if (existing_lhs ~= '' and existing_lhs:sub(1, 13) ~= '<Plug>(vimtex') then
     return
   end
@@ -37,9 +37,8 @@ function M.vimtex_map(key, vimtex_mapping, desc)
   local vimtex_key = vimtex_mapping:sub(2, 2)
   local forward = vimtex_mapping:sub(1, 1) == ']'
 
-  local nxo = { 'n', 'x', 'o' }
-
-  vim.keymap.set(nxo, key, M.jump({ forward = forward, vimtex_key = vimtex_key }), { desc = desc, buffer = true })
+  vim.keymap.set('n', key, M.jump({ forward = forward, vimtex_key = vimtex_key }),
+    { desc = desc, buffer = true, noremap = true, silent = true })
 end
 
 function M.create_keymaps()

--- a/lua/demicolon/integrations/vimtex.lua
+++ b/lua/demicolon/integrations/vimtex.lua
@@ -67,8 +67,8 @@ function M.create_keymaps()
     group = vim.api.nvim_create_augroup('demicolon_vimtex_keymap', {}),
     pattern = "tex",
     callback = function()
-      M.vimtex_map(keymaps.section_begin.next, "][", "Next section begin")
-      M.vimtex_map(keymaps.section_begin.prev, "[[", "Previous section begin")
+      M.vimtex_map(keymaps.section_start.next, "][", "Next section start")
+      M.vimtex_map(keymaps.section_start.prev, "[[", "Previous section start")
 
       M.vimtex_map(keymaps.section_end.next, "]]", "Next section end")
       M.vimtex_map(keymaps.section_end.prev, "[]", "Previous section end")

--- a/lua/demicolon/integrations/vimtex.lua
+++ b/lua/demicolon/integrations/vimtex.lua
@@ -19,10 +19,10 @@ function M.jump(options)
 
       -- Manually store the count and prepend it to the mapping to preserve it
       local count = vim.v.count
-      local count_str = count > 1 and tostring(count) or ""
-      local mapping = count_str .. "<Plug>(vimtex-" .. vimtex_mapping .. ")"
+      local count_str = count > 1 and tostring(count) or ''
+      local mapping = count_str .. '<Plug>(vimtex-' .. vimtex_mapping .. ')'
       local plug_mapping = vim.api.nvim_replace_termcodes(mapping, true, false, true)
-      vim.api.nvim_feedkeys(plug_mapping, "m", false)
+      vim.api.nvim_feedkeys(plug_mapping, 'm', false)
     end, options)
   end
 end
@@ -34,13 +34,13 @@ function M.vimtex_map(key, vimtex_mapping, desc)
   -- Override only if it's a vimtex mapping or not set.
   -- That's roughly the behavior of vimtex as well:
   -- https://github.com/lervag/vimtex/blob/83e331dcad5ce28012e656eea3906b5b897db2ba/autoload/vimtex.vim#L415
-  local existing_lhs = vim.fn.maparg(vimtex_mapping, "nxo")
-  if (existing_lhs ~= '' and existing_lhs:sub(1, 13) ~= "<Plug>(vimtex") then
+  local existing_lhs = vim.fn.maparg(vimtex_mapping, 'nxo')
+  if (existing_lhs ~= '' and existing_lhs:sub(1, 13) ~= '<Plug>(vimtex') then
     return
   end
 
   local vimtex_key = vimtex_mapping:sub(2, 2)
-  local forward = vimtex_mapping:sub(1, 1) == "]"
+  local forward = vimtex_mapping:sub(1, 1) == ']'
 
   local nxo = { 'n', 'x', 'o' }
 
@@ -55,39 +55,39 @@ function M.create_keymaps()
     return
   end
 
-  vim.api.nvim_create_autocmd("FileType", {
+  vim.api.nvim_create_autocmd('FileType', {
     group = vim.api.nvim_create_augroup('demicolon_vimtex_keymap', {}),
-    pattern = "tex",
+    pattern = 'tex',
     callback = function()
-      M.vimtex_map(keymaps.section_start.next, "][", "Next section start")
-      M.vimtex_map(keymaps.section_start.prev, "[[", "Previous section start")
+      M.vimtex_map(keymaps.section_start.next, '][', 'Next section start')
+      M.vimtex_map(keymaps.section_start.prev, '[[', 'Previous section start')
 
-      M.vimtex_map(keymaps.section_end.next, "]]", "Next section end")
-      M.vimtex_map(keymaps.section_end.prev, "[]", "Previous section end")
+      M.vimtex_map(keymaps.section_end.next, ']]', 'Next section end')
+      M.vimtex_map(keymaps.section_end.prev, '[]', 'Previous section end')
 
-      M.vimtex_map(keymaps.frame_start.next, "]r", "Next frame start")
-      M.vimtex_map(keymaps.frame_start.prev, "[r", "Previous frame start")
+      M.vimtex_map(keymaps.frame_start.next, ']r', 'Next frame start')
+      M.vimtex_map(keymaps.frame_start.prev, '[r', 'Previous frame start')
 
-      M.vimtex_map(keymaps.frame_end.next, "]R", "Next frame end")
-      M.vimtex_map(keymaps.frame_end.prev, "[R", "Previous frame end")
+      M.vimtex_map(keymaps.frame_end.next, ']R', 'Next frame end')
+      M.vimtex_map(keymaps.frame_end.prev, '[R', 'Previous frame end')
 
-      M.vimtex_map(keymaps.math_start.next, "]n", "Next math start")
-      M.vimtex_map(keymaps.math_start.prev, "[n", "Previous math start")
+      M.vimtex_map(keymaps.math_start.next, ']n', 'Next math start')
+      M.vimtex_map(keymaps.math_start.prev, '[n', 'Previous math start')
 
-      M.vimtex_map(keymaps.math_end.next, "]N", "Next math end")
-      M.vimtex_map(keymaps.math_end.prev, "[N", "Previous math end")
+      M.vimtex_map(keymaps.math_end.next, ']N', 'Next math end')
+      M.vimtex_map(keymaps.math_end.prev, '[N', 'Previous math end')
 
-      M.vimtex_map(keymaps.comment_start.next, "]/", "Next comment start")
-      M.vimtex_map(keymaps.comment_start.prev, "[/", "Previous comment start")
+      M.vimtex_map(keymaps.comment_start.next, ']/', 'Next comment start')
+      M.vimtex_map(keymaps.comment_start.prev, '[/', 'Previous comment start')
 
-      M.vimtex_map(keymaps.comment_end.next, "]%", "Next comment end")
-      M.vimtex_map(keymaps.comment_end.prev, "[%", "Previous comment end")
+      M.vimtex_map(keymaps.comment_end.next, ']%', 'Next comment end')
+      M.vimtex_map(keymaps.comment_end.prev, '[%', 'Previous comment end')
 
-      M.vimtex_map(keymaps.environment_start.next, "]m", "Next environment start")
-      M.vimtex_map(keymaps.environment_start.prev, "[m", "Previous environment start")
+      M.vimtex_map(keymaps.environment_start.next, ']m', 'Next environment start')
+      M.vimtex_map(keymaps.environment_start.prev, '[m', 'Previous environment start')
 
-      M.vimtex_map(keymaps.environment_end.next, "]M", "Next environment end")
-      M.vimtex_map(keymaps.environment_end.prev, "[M", "Previous environment end")
+      M.vimtex_map(keymaps.environment_end.next, ']M', 'Next environment end')
+      M.vimtex_map(keymaps.environment_end.prev, '[M', 'Previous environment end')
     end,
   })
 end

--- a/lua/demicolon/integrations/vimtex.lua
+++ b/lua/demicolon/integrations/vimtex.lua
@@ -29,7 +29,7 @@ function M.vimtex_map(key, vimtex_mapping, desc)
   -- Override only if it's a vimtex mapping or not set.
   -- That's roughly the behavior of vimtex as well:
   -- https://github.com/lervag/vimtex/blob/83e331dcad5ce28012e656eea3906b5b897db2ba/autoload/vimtex.vim#L415
-  local existing_lhs = vim.fn.maparg(vimtex_mapping, 'n')
+  local existing_lhs = vim.fn.maparg(vimtex_mapping, 'nx')
   if (existing_lhs ~= '' and existing_lhs:sub(1, 13) ~= '<Plug>(vimtex') then
     return
   end
@@ -37,7 +37,9 @@ function M.vimtex_map(key, vimtex_mapping, desc)
   local vimtex_key = vimtex_mapping:sub(2, 2)
   local forward = vimtex_mapping:sub(1, 1) == ']'
 
-  vim.keymap.set('n', key, M.jump({ forward = forward, vimtex_key = vimtex_key }),
+  local nx = { 'n', 'x' }
+
+  vim.keymap.set(nx, key, M.jump({ forward = forward, vimtex_key = vimtex_key }),
     { desc = desc, buffer = true, noremap = true, silent = true })
 end
 

--- a/lua/demicolon/integrations/vimtex.lua
+++ b/lua/demicolon/integrations/vimtex.lua
@@ -79,8 +79,8 @@ function M.create_keymaps()
       M.vimtex_map(keymaps.comment_start.next, ']/', 'Next comment start')
       M.vimtex_map(keymaps.comment_start.prev, '[/', 'Previous comment start')
 
-      M.vimtex_map(keymaps.comment_end.next, ']%', 'Next comment end')
-      M.vimtex_map(keymaps.comment_end.prev, '[%', 'Previous comment end')
+      M.vimtex_map(keymaps.comment_end.next, ']*', 'Next comment end')
+      M.vimtex_map(keymaps.comment_end.prev, '[*', 'Previous comment end')
 
       M.vimtex_map(keymaps.environment_start.next, ']m', 'Next environment start')
       M.vimtex_map(keymaps.environment_start.prev, '[m', 'Previous environment start')

--- a/lua/demicolon/integrations/vimtex.lua
+++ b/lua/demicolon/integrations/vimtex.lua
@@ -4,11 +4,6 @@ local M = {}
 function M.jump(options)
   return function()
     require('demicolon.jump').repeatably_do(function(opts)
-      if vim.fn.exists(':VimtexCompile') ~= 2 then
-        vim.notify('demicolon.nvim: vimtex is not installed', vim.log.levels.WARN)
-        return
-      end
-
       local direction = (opts.forward == nil or opts.forward) and ']' or '['
       local vimtex_mapping = direction .. opts.vimtex_key
 
@@ -59,6 +54,10 @@ function M.create_keymaps()
     group = vim.api.nvim_create_augroup('demicolon_vimtex_keymap', {}),
     pattern = 'tex',
     callback = function()
+      if vim.fn.exists(':VimtexCompile') ~= 2 then
+        return
+      end
+
       M.vimtex_map(keymaps.section_start.next, '][', 'Next section start')
       M.vimtex_map(keymaps.section_start.prev, '[[', 'Previous section start')
 

--- a/lua/demicolon/integrations/vimtex.lua
+++ b/lua/demicolon/integrations/vimtex.lua
@@ -1,0 +1,103 @@
+local M = {}
+
+---@param options { forward?: boolean, vimtex_key: string }
+function M.jump(options)
+  return function()
+    require('demicolon.jump').repeatably_do(function(opts)
+      if vim.fn.exists(':VimtexCompile') ~= 2 then
+        vim.notify('demicolon.nvim: vimtex is not installed', vim.log.levels.WARN)
+        return
+      end
+
+      local direction = (opts.forward == nil or opts.forward) and 'next' or 'prev'
+
+      local vimtex_key = opts.vimtex_key
+      local vimtex_mapping = ""
+
+      if direction == "prev" then
+        vimtex_mapping = "[" .. vimtex_key
+      else
+        vimtex_mapping = "]" .. vimtex_key
+      end
+
+      -- Vimtex does not use lua to map to their functions, but special <Plug>
+      -- mappings, which we have to map to.
+      -- All mappings of the desired type are listed here:
+      -- https://github.com/lervag/vimtex/blob/83e331dcad5ce28012e656eea3906b5b897db2ba/doc/vimtex.txt#L3899
+
+      -- Manually store the count and prepend it to the mapping to preserve it
+      local count = vim.v.count
+      local count_str = count > 1 and tostring(count) or ""
+      local mapping = count_str .. "<Plug>(vimtex-" .. vimtex_mapping .. ")"
+      local plug_mapping = vim.api.nvim_replace_termcodes(mapping, true, false, true)
+      vim.api.nvim_feedkeys(plug_mapping, "m", false)
+    end, options)
+  end
+end
+
+---@param key string the key to map this to
+---@param vimtex_mapping string the original vimtex mapping
+---@param desc string the description of the mapping
+function M.vimtex_map(key, vimtex_mapping, desc)
+  -- Override only if it's a vimtex mapping or not set.
+  -- That's roughly the behavior of vimtex as well:
+  -- https://github.com/lervag/vimtex/blob/83e331dcad5ce28012e656eea3906b5b897db2ba/autoload/vimtex.vim#L415
+  local existing_lhs = vim.fn.maparg(vimtex_mapping, "nxo")
+  if (existing_lhs ~= '' and existing_lhs:sub(1, 13) ~= "<Plug>(vimtex") then
+    return
+  end
+
+  local vimtex_key = vimtex_mapping:sub(2, 2)
+  local forward = vimtex_mapping:sub(1, 1) == "]"
+
+  local nxo = { 'n', 'x', 'o' }
+
+  vim.keymap.set(nxo, key, M.jump({ forward = forward, vimtex_key = vimtex_key }), { desc = desc, buffer = true })
+end
+
+function M.create_keymaps()
+  local options = require('demicolon').get_options().integrations.vimtex
+  local keymaps = options and options.keymaps
+
+  if not options or not options.enabled or not keymaps then
+    return
+  end
+
+  vim.api.nvim_create_autocmd("FileType", {
+    group = vim.api.nvim_create_augroup('demicolon_vimtex_keymap', {}),
+    pattern = "tex",
+    callback = function()
+      M.vimtex_map(keymaps.section_begin.next, "][", "Next section begin")
+      M.vimtex_map(keymaps.section_begin.prev, "[[", "Previous section begin")
+
+      M.vimtex_map(keymaps.section_end.next, "]]", "Next section end")
+      M.vimtex_map(keymaps.section_end.prev, "[]", "Previous section end")
+
+      M.vimtex_map(keymaps.frame_start.next, "]r", "Next frame start")
+      M.vimtex_map(keymaps.frame_start.prev, "[r", "Previous frame start")
+
+      M.vimtex_map(keymaps.frame_end.next, "]R", "Next frame end")
+      M.vimtex_map(keymaps.frame_end.prev, "[R", "Previous frame end")
+
+      M.vimtex_map(keymaps.math_start.next, "]n", "Next math start")
+      M.vimtex_map(keymaps.math_start.prev, "[n", "Previous math start")
+
+      M.vimtex_map(keymaps.math_end.next, "]N", "Next math end")
+      M.vimtex_map(keymaps.math_end.prev, "[N", "Previous math end")
+
+      M.vimtex_map(keymaps.comment_start.next, "]/", "Next comment start")
+      M.vimtex_map(keymaps.comment_start.prev, "[/", "Previous comment start")
+
+      M.vimtex_map(keymaps.comment_end.next, "]%", "Next comment end")
+      M.vimtex_map(keymaps.comment_end.prev, "[%", "Previous comment end")
+
+      M.vimtex_map(keymaps.environment_start.next, "]m", "Next environment start")
+      M.vimtex_map(keymaps.environment_start.prev, "[m", "Previous environment start")
+
+      M.vimtex_map(keymaps.environment_end.next, "]M", "Next environment end")
+      M.vimtex_map(keymaps.environment_end.prev, "[M", "Previous environment end")
+    end,
+  })
+end
+
+return M

--- a/lua/demicolon/integrations/vimtex.lua
+++ b/lua/demicolon/integrations/vimtex.lua
@@ -9,16 +9,8 @@ function M.jump(options)
         return
       end
 
-      local direction = (opts.forward == nil or opts.forward) and 'next' or 'prev'
-
-      local vimtex_key = opts.vimtex_key
-      local vimtex_mapping = ""
-
-      if direction == "prev" then
-        vimtex_mapping = "[" .. vimtex_key
-      else
-        vimtex_mapping = "]" .. vimtex_key
-      end
+      local direction = (opts.forward == nil or opts.forward) and ']' or '['
+      local vimtex_mapping = direction .. opts.vimtex_key
 
       -- Vimtex does not use lua to map to their functions, but special <Plug>
       -- mappings, which we have to map to.


### PR DESCRIPTION
This pr adds an integration for the [vimtex](https://github.com/lervag/vimtex) plugin. This adds quite more keymaps than the other integrations, and it's more complicated to simulate the original key press, because it does not provide a lua interface.
So I'm curious what you think about this integration.

For me, a nice addition with this integration is a better description in which-key, because it now shows the actual action and not just `vimtex-]])`.