### PR TITLE
fix: correct vimtex motion naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ Note that these mappings are only created in normal mode and visual mode. For so
 
 | Motion    | Jumps to next/pevious... | Help page with more information |
 | --------- | ------------------------ | ------------------------------- |
-| `][`/`[[` | Section start            | `:help vimtex-motions`          |
-| `]]`/`[]` | Section end              | `:help vimtex-motions`          |
+| `]]`/`[[` | Section start            | `:help vimtex-motions`          |
+| `][`/`[]` | Section end              | `:help vimtex-motions`          |
 | `]r`/`[r` | Frame start              | `:help vimtex-motions`          |
 | `]R`/`[R` | Frame end                | `:help vimtex-motions`          |
 | `]n`/`[n` | Math start               | `:help vimtex-motions`          |
@@ -150,11 +150,11 @@ opts = {
       enabled = true,
       keymaps = {
         section_start = {
-          next = '][',
+          next = ']]',
           prev = '[[',
         },
         section_end = {
-          next = ']]',
+          next = '][',
           prev = '[]',
         },
         frame_start = {

--- a/lua/demicolon/init.lua
+++ b/lua/demicolon/init.lua
@@ -91,11 +91,11 @@ local options = {
       enabled = true,
       keymaps = {
         section_start = {
-          next = '][',
+          next = ']]',
           prev = '[[',
         },
         section_end = {
-          next = ']]',
+          next = '][',
           prev = '[]',
         },
         frame_start = {

--- a/lua/demicolon/integrations/vimtex.lua
+++ b/lua/demicolon/integrations/vimtex.lua
@@ -59,10 +59,10 @@ function M.create_keymaps()
         return
       end
 
-      M.vimtex_map(keymaps.section_start.next, '][', 'Next section start')
+      M.vimtex_map(keymaps.section_start.next, ']]', 'Next section start')
       M.vimtex_map(keymaps.section_start.prev, '[[', 'Previous section start')
 
-      M.vimtex_map(keymaps.section_end.next, ']]', 'Next section end')
+      M.vimtex_map(keymaps.section_end.next, '][', 'Next section end')
       M.vimtex_map(keymaps.section_end.prev, '[]', 'Previous section end')
 
       M.vimtex_map(keymaps.frame_start.next, ']r', 'Next frame start')


### PR DESCRIPTION
In the previous version, I've based the naming for the key mappings on the documentation, but it turned out to be wrong. So this commit fixes this.

https://github.com/lervag/vimtex/issues/3094

The integration has not been released for a long time, so I think these changes are okay. Sorry for the trouble with this vimtex integration.