### PR TITLE
feat: add option to match Vim's default behaviour for ; and ,

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,11 @@ opts = {
   keymaps = {
     -- Create t/T/f/F key mappings
     horizontal_motions = true,
-    -- Create ; and , key mappings
-    repeat_motions = true,
+    -- Create ; and , key mappings. Set it to 'stateless', 'stateful', or false to
+    -- not create any mappings. 'stateless' means that ;/, move right/left.
+    -- 'stateful' means that ;/, will remember the direction of the original
+    -- jump, and `,` inverts that direction (Neovim's default behaviour).
+    repeat_motions = 'stateless',
     -- Keys that shouldn't be repeatable (because aren't motions), excluding the prefix `]`/`[`
     -- If you have custom motions that use one of these, make sure to remove that key from here
     disabled_keys = { 'p', 'I', 'A', 'f', 'i' },

--- a/lua/demicolon/init.lua
+++ b/lua/demicolon/init.lua
@@ -34,9 +34,9 @@ function M.setup(opts)
     keymaps.create_default_horizontal_keymaps()
   end
 
-  local direction = options.keymaps.repeat_motions
-  if direction then
-    keymaps.create_default_repeat_keymaps(direction)
+  local repeat_behaviour = options.keymaps.repeat_motions
+  if repeat_behaviour ~= false then
+    keymaps.create_default_repeat_keymaps(repeat_behaviour)
   end
 
   require('demicolon.deprecation').warn_for_deprecated_options(options)

--- a/lua/demicolon/init.lua
+++ b/lua/demicolon/init.lua
@@ -7,7 +7,7 @@ local M = {}
 
 ---@class demicolon.keymaps.options
 ---@field horizontal_motions? boolean Create `t`/`T`/`f`/`F` key mappings
----@field repeat_motions? boolean Create `;` and `,` key mappings
+---@field repeat_motions? false|'stateless'|'stateful' Create `;` and `,` key mappings
 ---@field disabled_keys? table<string> Keys that shouldn't be repeatable (because aren't motions), excluding the prefix `]`/`[`
 
 ---@class demicolon.options
@@ -16,7 +16,7 @@ local M = {}
 local options = {
   keymaps = {
     horizontal_motions = true,
-    repeat_motions = true,
+    repeat_motions = 'stateless',
     disabled_keys = { 'p', 'I', 'A', 'f', 'i' },
   },
 }
@@ -34,8 +34,9 @@ function M.setup(opts)
     keymaps.create_default_horizontal_keymaps()
   end
 
-  if options.keymaps.repeat_motions then
-    keymaps.create_default_repeat_keymaps()
+  local direction = options.keymaps.repeat_motions
+  if direction then
+    keymaps.create_default_repeat_keymaps(direction)
   end
 
   require('demicolon.deprecation').warn_for_deprecated_options(options)

--- a/lua/demicolon/init.lua
+++ b/lua/demicolon/init.lua
@@ -7,7 +7,7 @@ local M = {}
 
 ---@class demicolon.keymaps.options
 ---@field horizontal_motions? boolean Create `t`/`T`/`f`/`F` key mappings
----@field repeat_motions? false|'stateless'|'stateful' Create `;` and `,` key mappings
+---@field repeat_motions? 'stateless' | 'stateful' | false Create `;` and `,` key mappings. `'stateless'` means that `;`/`,` move right/left. `'stateful'` means that `;`/`,` will remember the direction of the original jump, and `,` inverts that direction (Neovim's default behaviour).
 ---@field disabled_keys? table<string> Keys that shouldn't be repeatable (because aren't motions), excluding the prefix `]`/`[`
 
 ---@class demicolon.options

--- a/lua/demicolon/keymaps.lua
+++ b/lua/demicolon/keymaps.lua
@@ -2,9 +2,17 @@ local M = {}
 
 local nxo = { 'n', 'x', 'o' }
 
-function M.create_default_repeat_keymaps()
-  vim.keymap.set(nxo, ';', require('demicolon.repeat_jump').forward)
-  vim.keymap.set(nxo, ',', require('demicolon.repeat_jump').backward)
+function M.create_default_repeat_keymaps(direction)
+  assert(type(direction) == "string" and (direction == 'stateless' or direction == 'stateful'), "repeat_motions must either be 'stateless' or 'stateful'")
+
+  local repeat_jump = require('demicolon.repeat_jump')
+  if direction == 'stateless' then
+    vim.keymap.set(nxo, ';', repeat_jump.forward)
+    vim.keymap.set(nxo, ',', repeat_jump.backward)
+  else
+    vim.keymap.set(nxo, ';', repeat_jump.next)
+    vim.keymap.set(nxo, ',', repeat_jump.prev)
+  end
 end
 
 function M.create_default_horizontal_keymaps()

--- a/lua/demicolon/keymaps.lua
+++ b/lua/demicolon/keymaps.lua
@@ -2,11 +2,18 @@ local M = {}
 
 local nxo = { 'n', 'x', 'o' }
 
-function M.create_default_repeat_keymaps(direction)
-  assert(type(direction) == "string" and (direction == 'stateless' or direction == 'stateful'), "repeat_motions must either be 'stateless' or 'stateful'")
+---@param repeat_behaviour 'stateless' | 'stateful'
+function M.create_default_repeat_keymaps(repeat_behaviour)
+  local is_valid_behaviour_type = type(repeat_behaviour) == 'string'
+      and repeat_behaviour == 'stateless' or repeat_behaviour == 'stateful'
+  assert(
+    is_valid_behaviour_type,
+    "demicolon.nvim: keymaps.repeat_motions must either be 'stateless' or 'stateful'"
+  )
 
   local repeat_jump = require('demicolon.repeat_jump')
-  if direction == 'stateless' then
+
+  if repeat_behaviour == 'stateless' then
     vim.keymap.set(nxo, ';', repeat_jump.forward)
     vim.keymap.set(nxo, ',', repeat_jump.backward)
   else


### PR DESCRIPTION
I'm not on my PC, so unfortunately I can't test this PR. Let me know if there's something wrong.

> ; worked for me before the fix, what motion were you trying to repeat?

I mapped `;` like said in the README using `vim.keymap.set(nxo, ';', require('demicolon.repeat_jump').next)`.

