### PR TITLE
fix: require path for treesitter textobjects on main branch

### DIFF
--- a/lua/demicolon/jump.lua
+++ b/lua/demicolon/jump.lua
@@ -8,7 +8,10 @@ local M = {}
 ---@param opts demicolon.jump.opts | table Options to pass to the function. Make sure to include the `forward` boolean
 ---@param additional_args? any[]
 function M.repeatably_do(func, opts, additional_args)
-  local ts_repeatable_move = require('nvim-treesitter.textobjects.repeatable_move')
+  local ok, ts_repeatable_move = pcall(require, 'nvim-treesitter-textobjects.repeatable_move')
+  if not ok then
+    ts_repeatable_move = require('nvim-treesitter.textobjects.repeatable_move')
+  end
 
   opts = opts or {}
   additional_args = additional_args or {}
@@ -24,7 +27,10 @@ end
 ---@param key 't' | 'T' | 'f' | 'F'
 ---@return fun(): string
 function M.horizontal_jump(key)
-  local ts_repeatable_move = require('nvim-treesitter.textobjects.repeatable_move')
+  local ok, ts_repeatable_move = pcall(require, 'nvim-treesitter-textobjects.repeatable_move')
+  if not ok then
+    ts_repeatable_move = require('nvim-treesitter.textobjects.repeatable_move')
+  end
 
   return function()
     return ts_repeatable_move['builtin_' .. key .. '_expr']()

--- a/lua/demicolon/listen.lua
+++ b/lua/demicolon/listen.lua
@@ -75,7 +75,10 @@ function M.listen_for_repetable_bracket_motions(disabled_keys)
     end
 
     if motion then
-      local ts_repeatable_move = require('nvim-treesitter.textobjects.repeatable_move')
+      local ok, ts_repeatable_move = pcall(require, 'nvim-treesitter-textobjects.repeatable_move')
+      if not ok then
+        ts_repeatable_move = require('nvim-treesitter.textobjects.repeatable_move')
+      end
       ts_repeatable_move.last_move = {
         func = function(opts)
           local new_motion = motion_from_direction(opts.forward, motion)

--- a/lua/demicolon/repeat_jump.lua
+++ b/lua/demicolon/repeat_jump.lua
@@ -1,4 +1,7 @@
-local ts_repeatable_move = require('nvim-treesitter.textobjects.repeatable_move')
+local ok, ts_repeatable_move = pcall(require, 'nvim-treesitter-textobjects.repeatable_move')
+if not ok then
+  ts_repeatable_move = require('nvim-treesitter.textobjects.repeatable_move')
+end
 
 local M = {}
 


### PR DESCRIPTION
In new treesitter/treesitter-textobjects version master branch have been frozen and now main is being used, the changes for treesitter-textobjects include change of path, this pr fixes that while remaining compatible with master branch changes