### PR TITLE
feat: add alternative repeat keymaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,28 @@ After pressing a `]`/`[`-prefixed key, for example `]q`, Demicolon lets you repe
 
 Of course, Demicolon also lets you repeat `t`/`T`/`f`/`F` with `;`/`,`. See [`:help t`](https://neovim.io/doc/user/motion.html#t), [`:help T`](https://neovim.io/doc/user/motion.html#T), [`:help f`](https://neovim.io/doc/user/motion.html#f), and [`:help F`](https://neovim.io/doc/user/motion.html#F) respectively for more information.
 
+### Alternative/custom repeat keys
+
+If you’d rather use something other than `;` and `,` to repeat the last demicolon-tracked motion, you can enable **alternative-repeat** in your setup:
+
+```lua
+require('demicolon').setup({
+  keymaps = {
+    -- disable the default ; / , if you don’t want them
+    repeat_motions = false,
+    -- turn on the new mechanism
+    alternative_repeat = {
+      enabled = true,
+      forward = { key = { 'n', '<Right>' }, fallback = 'n'  },
+      backward = { key = 'N',                fallback = 'N'  },
+      -- fallback is sent if there is no demicolon-tracked motion
+    },
+  },
+})
+```
+
+After this, pressing `n` or `<Right>` will repeat forward, and `N` will repeat backward, just like `;` and `,` would—but only for motions tracked by demicolon.nvim.
+
 ### Examples of repeatable motions
 
 Below are some examples of motions, both built-in and provided by plugins.
@@ -162,6 +184,12 @@ opts = {
     -- 'stateful' means that ;/, will remember the direction of the original
     -- jump, and `,` inverts that direction (Neovim's default behaviour).
     repeat_motions = 'stateless',
+    -- Configure alternative repeat keys
+    alternative_repeat = {
+      enabled = false,   -- set true to use alternative keys
+      forward = { key = 'n',  fallback = 'n'  }, -- example
+      backward = { key = 'N',  fallback = 'N'  }, -- example
+    },
     -- Keys that shouldn't be repeatable (because aren't motions), excluding the prefix `]`/`[`
     -- If you have custom motions that use one of these, make sure to remove that key from here
     disabled_keys = { 'p', 'I', 'A', 'f', 'i' },

--- a/lua/demicolon/init.lua
+++ b/lua/demicolon/init.lua
@@ -5,10 +5,20 @@ local M = {}
 ---@class demicolon.diagnostic.options
 ---@field float? boolean|vim.diagnostic.Opts.Float Default options passed to diagnostic floating window
 
+---@class demicolon.alternative_repeat.spec
+---@field key       string|string[]        Key(s) that trigger the repeat
+---@field fallback? string                 Fed when no demicolon motion is active
+
+---@class demicolon.alternative_repeat.options
+---@field enabled          boolean
+---@field forward?         demicolon.alternative_repeat.spec
+---@field backward?        demicolon.alternative_repeat.spec
+
 ---@class demicolon.keymaps.options
 ---@field horizontal_motions? boolean Create `t`/`T`/`f`/`F` key mappings
 ---@field repeat_motions? 'stateless' | 'stateful' | false Create `;` and `,` key mappings. `'stateless'` means that `;`/`,` move right/left. `'stateful'` means that `;`/`,` will remember the direction of the original jump, and `,` inverts that direction (Neovim's default behaviour).
 ---@field disabled_keys? table<string> Keys that shouldn't be repeatable (because aren't motions), excluding the prefix `]`/`[`
+---@field alternative_repeat? demicolon.alternative_repeat.options
 
 ---@class demicolon.options
 ---@field diagnostic? demicolon.diagnostic.options Diagnostic options
@@ -18,6 +28,11 @@ local options = {
     horizontal_motions = true,
     repeat_motions = 'stateless',
     disabled_keys = { 'p', 'I', 'A', 'f', 'i' },
+    alternative_repeat = {
+      enabled = false,
+      forward = {},
+      backward = {},
+    },
   },
 }
 
@@ -30,13 +45,28 @@ end
 function M.setup(opts)
   options = vim.tbl_deep_extend('force', options, opts or {})
 
+  local alt = options.keymaps.alternative_repeat or { enabled = false }
+
   if options.keymaps.horizontal_motions then
     keymaps.create_default_horizontal_keymaps()
   end
 
   local repeat_behaviour = options.keymaps.repeat_motions
-  if repeat_behaviour ~= false then
+  if (not alt.enabled) and repeat_behaviour ~= false then
     keymaps.create_default_repeat_keymaps(repeat_behaviour)
+  end
+
+  if alt.enabled then
+    keymaps.create_alternative_repeat_keymaps(alt)
+
+    local ts_move = require('nvim-treesitter.textobjects.repeatable_move')
+    vim.api.nvim_create_autocmd('CmdlineLeave', {
+      pattern = { '/', '\\?' },
+      callback = function()
+        ts_move.last_move = nil
+      end,
+      desc = 'demicolon.nvim: reset alt-repeat after / or ?',
+    })
   end
 
   require('demicolon.deprecation').warn_for_deprecated_options(options)

--- a/lua/demicolon/keymaps.lua
+++ b/lua/demicolon/keymaps.lua
@@ -5,11 +5,8 @@ local nxo = { 'n', 'x', 'o' }
 ---@param repeat_behaviour 'stateless' | 'stateful'
 function M.create_default_repeat_keymaps(repeat_behaviour)
   local is_valid_behaviour_type = type(repeat_behaviour) == 'string'
-      and repeat_behaviour == 'stateless' or repeat_behaviour == 'stateful'
-  assert(
-    is_valid_behaviour_type,
-    "demicolon.nvim: keymaps.repeat_motions must either be 'stateless' or 'stateful'"
-  )
+    and (repeat_behaviour == 'stateless' or repeat_behaviour == 'stateful')
+  assert(is_valid_behaviour_type, 'demicolon.nvim: keymaps.repeat_motions must either be \'stateless\' or \'stateful\'')
 
   local repeat_jump = require('demicolon.repeat_jump')
 
@@ -20,6 +17,43 @@ function M.create_default_repeat_keymaps(repeat_behaviour)
     vim.keymap.set(nxo, ';', repeat_jump.next)
     vim.keymap.set(nxo, ',', repeat_jump.prev)
   end
+end
+
+---@param cfg demicolon.alternative_repeat.options
+function M.create_alternative_repeat_keymaps(cfg)
+  local repeat_jump = require('demicolon.repeat_jump')
+  local ts_repeatable_move = require('nvim-treesitter.textobjects.repeatable_move')
+
+  local function has_motion()
+    return ts_repeatable_move.last_move ~= nil
+  end
+
+  ---@param spec demicolon.alternative_repeat.spec
+  local function register(spec, dir_fn, description)
+    if not spec or not spec.key or spec.key == '' then
+      return
+    end
+
+    local raw_keys = type(spec.key) == 'table' and spec.key or { spec.key }
+    ---@cast raw_keys string[]
+
+    for _, lhs in ipairs(raw_keys) do
+      vim.keymap.set('n', lhs, function()
+        if has_motion() then
+          dir_fn()
+        else
+          local feed = vim.api.nvim_replace_termcodes(spec.fallback or lhs, true, false, true)
+          vim.api.nvim_feedkeys(feed, 'ni', false)
+        end
+      end, {
+        desc = description,
+        noremap = true,
+      })
+    end
+  end
+
+  register(cfg.forward, repeat_jump.next, 'demicolon alt-repeat forward')
+  register(cfg.backward, repeat_jump.prev, 'demicolon alt-repeat backward')
 end
 
 function M.create_default_horizontal_keymaps()


### PR DESCRIPTION
## Add support for custom repeat keys

// *feat: enable alternative-repeat keymaps in demicolon.nvim*

**Why this?**
Users often want to use more intuitive or familiar keys—like `n`/`N` or `<Right>`—to repeat motions (e.g. treesitter jumps), instead of the default `;` and `,`. This change adds full configurability for that.

---

### What’s new

* **Configurable `alternative_repeat` option** with `forward` and `backward` keys, plus optional `fallback` behavior.
* Users can disable `repeat_motions` (`;`/`,`) and enable these alternate keys instead.
* Fallback sends the raw key (e.g. `'n'`) when there's no demicolon‑tracked motion.
* Mappings are **non‑recursive** to prevent infinite loops, even if the fallback overlaps the trigger.
* Integrates cleanly with existing Treesitter repeat logic, search repeat, etc.

---

### Example config

```lua
require('demicolon').setup({
  keymaps = {
    repeat_motions = false,  -- disable built‑in ; / ,
    alternative_repeat = {
      enabled  = true,
      forward  = { key = { 'n', '<Right>' }, fallback = 'n' },
      backward = { key = 'N',                fallback = 'N' },
    },
  },
})
```

* **`forward`**: uses `n` or Right‑arrow to jump forward on repeat.
* **`backward`**: uses `N` to jump backward.
* If no demicolon motion is active (e.g., after a search), fallback sends `n`/`N` as usual.

---

### Details

* Applies **in normal mode**
* Tested and works as expected.
* No regression with existing `;` / `,` behavior when `alternative_repeat` is disabled.

---

### Why it matters

This enhancement lets users continue using their preferred keys and muscle memory (like Vim’s `n`/`N`) for repeatable navigation, while still benefiting from demicolon’s rich repeatability across custom motions.