### PR TITLE
fix: avoid error in jumping at the first time

### DIFF
--- a/lua/demicolon/repeat_jump.lua
+++ b/lua/demicolon/repeat_jump.lua
@@ -22,11 +22,11 @@ end
 
 --- Like `backward`, but repeats based on the direction of the original jump.
 function M.prev()
-  local opts = {
-    forward = not ts_repeatable_move.last_move.opts.forward,
-    repeated = true,
-  }
-  return ts_repeatable_move.last_move and ts_repeatable_move.repeat_last_move(opts)
+  local opts = { repeated = true }
+  if ts_repeatable_move.last_move then
+    opts.forward = not ts_repeatable_move.last_move.opts.forward
+  end
+  return ts_repeatable_move.repeat_last_move(opts)
 end
 
 return M


### PR DESCRIPTION
Without this, it occurs an error below.

```
E5108: Lua: ...e/nvim/lazy/demicolon.nvim/lua/demicolon/repeat_jump.lua:29: attempt to index field 'last_move' (a nil value)
stack traceback:
...e/nvim/lazy/demicolon.nvim/lua/demicolon/repeat_jump.lua:29: in function <...e/nvim/lazy/demicolon.nvim/lua/demicolon/repeat_jump.lua:24>
```

This is because `ts_repeatable_move.last_move` is `nil` just after loading the module. This PR fixes it.